### PR TITLE
Remove rspec-support from project list

### DIFF
--- a/_projects.yml
+++ b/_projects.yml
@@ -61,4 +61,3 @@
 - rspec/rspec-expectations
 - rspec/rspec-mocks
 - rspec/rspec-rails
-- rspec/rspec-support


### PR DESCRIPTION
That repo is not meant for public consumption, and so 
making documentation coverage visible is not desirable.
