### PR TITLE
Add my projects

### DIFF
--- a/_projects.yml
+++ b/_projects.yml
@@ -11,6 +11,8 @@
 - cequel/cequel
 - docwhat/lego_nxt
 - danijoo/Sightstone
+- ddfreyne/cri
+- ddfreyne/ddplugin
 - floere/phony
 - guard/guard
 - hajee/easy_type
@@ -29,6 +31,8 @@
 - mbleigh/acts-as-taggable-on
 - metricfu/metric_fu
 - minimagick/minimagick
+- nanoc/nanoc
+- nanoc/nanoc-core
 - neopoly/on
 - pboling/capistrano_mailer
 - pboling/csv_pirate


### PR DESCRIPTION
This adds:
- cri
- ddplugin
- nanoc
- nanoc-core

The former two are small and will be easy to get to super-good documentation coverage, while the latter are much larger but also more important.
